### PR TITLE
Add horizontal force toggle.

### DIFF
--- a/Mod/Data/Scripts/HoverRail/CurvedRailGuides.cs
+++ b/Mod/Data/Scripts/HoverRail/CurvedRailGuides.cs
@@ -1,4 +1,5 @@
 using System;
+using VRage.Game.ModAPI;
 using VRageMath;
 
 namespace HoverRail {

--- a/Mod/Data/Scripts/HoverRail/DebugDraw.cs
+++ b/Mod/Data/Scripts/HoverRail/DebugDraw.cs
@@ -1,3 +1,4 @@
+using VRage.Game;
 using VRageMath;
 
 namespace HoverRail {

--- a/Mod/Data/Scripts/HoverRail/HoverEngine.cs
+++ b/Mod/Data/Scripts/HoverRail/HoverEngine.cs
@@ -182,6 +182,7 @@ namespace HoverRail
             float height = (float)SettingsStore.Get(Entity, "height_offset", EngineUIMini.DefaultHeightM);
 
             double forceLimit = (double)(float)SettingsStore.Get(Entity, "force_slider", EngineUIMini.DefaultForceMWN);
+            bool horizontalForce = (bool)SettingsStore.Get(Entity, "horizontal_force", true);
 
             var hoverCenter = Entity.WorldMatrix.Translation;
             var searchCenter = Entity.WorldMatrix.Translation + Entity.WorldMatrix.Down * 2.499;
@@ -194,7 +195,7 @@ namespace HoverRail
 
             foreach (var guide in activeRailGuides)
             {
-                if (!guide.getGuidance(hoverCenter, ref rail_pos, ref weight_sum, height))
+                if (!guide.getGuidance(hoverCenter, horizontalForce, ref rail_pos, ref weight_sum, height))
                 {
                     // lost rail lock
                     lostGuides.Add(guide);
@@ -222,7 +223,7 @@ namespace HoverRail
 
                     if (guide != null)
                     {
-                        var test = guide.getGuidance(hoverCenter, ref rail_pos, ref weight_sum, height);
+                        var test = guide.getGuidance(hoverCenter, horizontalForce, ref rail_pos, ref weight_sum, height);
 
                         if (test)
                         {
@@ -326,7 +327,7 @@ namespace HoverRail
         public static bool initialized = false;
         public static IMyTerminalControlSlider forceSlider, heightSlider, damperSlider;
         public static IMyTerminalAction lowerHeightAction, raiseHeightAction;
-        public static IMyTerminalControlOnOffSwitch soundOnOffSwitch;
+        public static IMyTerminalControlOnOffSwitch soundOnOffSwitch, horizontalForceSwitch;
 
         public static float DefaultHeightM = 0.9f;
         public static float DefaultForceMWN = 10000.0f;
@@ -394,6 +395,16 @@ namespace HoverRail
             soundOnOffSwitch.OffText = MyStringId.GetOrCompute("Off");
             soundOnOffSwitch.Visible = BlockIsEngine;
             MyAPIGateway.TerminalControls.AddControl<IMyUpgradeModule>(soundOnOffSwitch);
+
+            horizontalForceSwitch = MyAPIGateway.TerminalControls.CreateControl<IMyTerminalControlOnOffSwitch, IMyUpgradeModule>("HoverRail_HorizontalForce");
+            horizontalForceSwitch.Title = MyStringId.GetOrCompute("Horizontal Force");
+            horizontalForceSwitch.Tooltip = MyStringId.GetOrCompute("Whether the engine exerts horizontal force.");
+            horizontalForceSwitch.Getter = b => (bool)SettingsStore.Get(b, "horizontal_force", true);
+            horizontalForceSwitch.Setter = (b, v) => SettingsStore.Set(b, "horizontal_force", v);
+            horizontalForceSwitch.OnText = MyStringId.GetOrCompute("On");
+            horizontalForceSwitch.OffText = MyStringId.GetOrCompute("Off");
+            horizontalForceSwitch.Visible = BlockIsEngine;
+            MyAPIGateway.TerminalControls.AddControl<IMyUpgradeModule>(horizontalForceSwitch);
 
             forceSlider = MyAPIGateway.TerminalControls.CreateControl<IMyTerminalControlSlider, IMyUpgradeModule>("HoverRail_ForceLimit");
             forceSlider.Title = MyStringId.GetOrCompute("Force Limit");

--- a/Mod/Data/Scripts/HoverRail/HoverEngine.cs
+++ b/Mod/Data/Scripts/HoverRail/HoverEngine.cs
@@ -14,7 +14,7 @@ using VRage.ModAPI;
 
 namespace HoverRail
 {
-    public class HoverRailEngine : MyGameLogicComponent
+    public class HoverEngine : MyGameLogicComponent
     {
         const float MAX_POWER_USAGE_MW = 1f;
         const float FORCE_POWER_COST_MW_N = 0.0000001f;
@@ -45,10 +45,10 @@ namespace HoverRail
 
         void EngineCustomInfo(IMyTerminalBlock block, StringBuilder builder)
         {
-            builder.AppendLine(String.Format("Required Power: {0}W", EngineUI.SIFormat(power_usage * 1000000)));
-            builder.AppendLine(String.Format("Max Required Power: {0}W", EngineUI.SIFormat(MAX_POWER_USAGE_MW * 1000000)));
-            builder.AppendLine(String.Format("Current Height: {0}M", (float)SettingsStore.Get(Entity, "height_offset", 1.25f)));
-            builder.AppendLine(String.Format("Target Height: {0}M", (float)SettingsStore.Get(Entity, "height_target", 1.25f)));
+            builder.AppendLine(String.Format("Required Power: {0}W", EngineUIMini.SIFormat(power_usage * 1000000)));
+            builder.AppendLine(String.Format("Max Required Power: {0}W", EngineUIMini.SIFormat(MAX_POWER_USAGE_MW * 1000000)));
+            builder.AppendLine(String.Format("Current Height: {0}M", (float)SettingsStore.Get(Entity, "height_offset", EngineUIMini.DefaultHeightM)));
+            builder.AppendLine(String.Format("Target Height: {0}M", (float)SettingsStore.Get(Entity, "height_target", EngineUIMini.DefaultHeightM)));
         }
 
         // init power usage
@@ -102,13 +102,7 @@ namespace HoverRail
         public void InitLate()
         {
             block_initialized = true;
-
-            // Remove other file no need to use, check block type here and init the correct UI
-
-
-
-
-            if (!EngineUI.initialized) EngineUI.InitLate(Entity as IMyTerminalBlock);
+            if (!EngineUIMini.initialized) EngineUIMini.InitLate(Entity as IMyTerminalBlock);
         }
         static int attachcount;
         int id;
@@ -131,7 +125,7 @@ namespace HoverRail
             // People kept reporting that the engine hum was audible at any distance.
             // I have no fucking clue why that would be the case, but it was probably super annoying, so the hum is just off now.
             // ---
-            // Added this as a terminal option may have been a game bug - testing
+            // Added this as a terminal option - testing
 
             if ((bool)SettingsStore.Get(Entity, "sound_toggle", false))
             {
@@ -183,13 +177,11 @@ namespace HoverRail
             }
             // MyLog.Default.WriteLine(String.Format("power ratio is {0}", power_ratio));
 
-            // Changing height can be janky, need to test a gradual change method
-
             ChangeEngineHeight();
 
-            float height = (float)SettingsStore.Get(Entity, "height_offset", 1.25f);
+            float height = (float)SettingsStore.Get(Entity, "height_offset", EngineUIMini.DefaultHeightM);
 
-            double forceLimit = (double)(float)SettingsStore.Get(Entity, "force_slider", 100000.0f);
+            double forceLimit = (double)(float)SettingsStore.Get(Entity, "force_slider", EngineUIMini.DefaultForceMWN);
 
             var hoverCenter = Entity.WorldMatrix.Translation;
             var searchCenter = Entity.WorldMatrix.Translation + Entity.WorldMatrix.Down * 2.499;
@@ -305,8 +297,8 @@ namespace HoverRail
 
         private void ChangeEngineHeight()
         {
-            float height = (float)SettingsStore.Get(Entity, "height_offset", 1.25f);
-            float target = (float)SettingsStore.Get(Entity, "height_target", 1.25f);
+            float height = (float)SettingsStore.Get(Entity, "height_offset", EngineUIMini.DefaultHeightM);
+            float target = (float)SettingsStore.Get(Entity, "height_target", EngineUIMini.DefaultHeightM);
 
             if (target != height)
             {
@@ -324,40 +316,24 @@ namespace HoverRail
         }
     }
 
-    [MyEntityComponentDescriptor(typeof(MyObjectBuilder_UpgradeModule), false, "HoverRail_Engine_Large")]
-    public class HoverRailEngineLarge : HoverRailEngine
-    {
-    }
-    // small needs a different name in blender than the large engine
-    // but the exporter also appends _Small, so...
-    [MyEntityComponentDescriptor(typeof(MyObjectBuilder_UpgradeModule), false, "HoverRail_Engine_Small_Small")]
-    public class HoverRailEngineSmall : HoverRailEngine
+    [MyEntityComponentDescriptor(typeof(MyObjectBuilder_UpgradeModule), false, "HoverRail_SmallHoverEngineSmall")]
+    public class HoverEngineSmall3x1 : HoverEngine
     {
     }
 
-    [MyEntityComponentDescriptor(typeof(MyObjectBuilder_UpgradeModule), false, "HoverRail_LargeHoverEngine")]
-    public class HoverEngineLarge : HoverRailEngine
-    {
-    }
-
-    [MyEntityComponentDescriptor(typeof(MyObjectBuilder_UpgradeModule), false, "HoverRail_SmallHoverEngine")]
-    public class HoverEngineSmall : HoverRailEngine
-    {
-    }
-
-    static class EngineUI
+    static class EngineUIMini
     {
         public static bool initialized = false;
         public static IMyTerminalControlSlider forceSlider, heightSlider, damperSlider;
         public static IMyTerminalAction lowerHeightAction, raiseHeightAction;
         public static IMyTerminalControlOnOffSwitch soundOnOffSwitch;
 
+        public static float DefaultHeightM = 0.9f;
+        public static float DefaultForceMWN = 10000.0f;
+
         public static bool BlockIsEngine(IMyTerminalBlock block)
         {
-            return block.BlockDefinition.SubtypeId == "HoverRail_Engine_Large"
-                || block.BlockDefinition.SubtypeId == "HoverRail_Engine_Small_Small"
-                || block.BlockDefinition.SubtypeId == "HoverRail_LargeHoverEngine"
-                || block.BlockDefinition.SubtypeId == "HoverRail_SmallHoverEngine";
+            return block.BlockDefinition.SubtypeId == "HoverRail_SmallHoverEngineSmall";
         }
 
         public static float LogRound(float f)
@@ -391,14 +367,14 @@ namespace HoverRail
 
         public static void LowerHeightAction(IMyTerminalBlock block)
         {
-            float height = (float)SettingsStore.Get(block, "height_offset", 1.25f);
+            float height = (float)SettingsStore.Get(block, "height_offset", DefaultHeightM);
             height = Math.Max(0.1f, (float)Math.Round(height - 0.1f, 1));
             SettingsStore.Set(block, "height_offset", height);
         }
 
         public static void RaiseHeightAction(IMyTerminalBlock block)
         {
-            float height = (float)SettingsStore.Get(block, "height_offset", 1.25f);
+            float height = (float)SettingsStore.Get(block, "height_offset", DefaultHeightM);
             height = Math.Min(2.5f, (float)Math.Round(height + 0.1f, 1));
             SettingsStore.Set(block, "height_offset", height);
         }
@@ -419,26 +395,25 @@ namespace HoverRail
             soundOnOffSwitch.Visible = BlockIsEngine;
             MyAPIGateway.TerminalControls.AddControl<IMyUpgradeModule>(soundOnOffSwitch);
 
-
             forceSlider = MyAPIGateway.TerminalControls.CreateControl<IMyTerminalControlSlider, IMyUpgradeModule>("HoverRail_ForceLimit");
             forceSlider.Title = MyStringId.GetOrCompute("Force Limit");
             forceSlider.Tooltip = MyStringId.GetOrCompute("The amount of force applied to align this motor with the track.");
-            forceSlider.SetLogLimits(10000.0f, 300000000.0f);
+            forceSlider.SetLogLimits(10000.0f, 30000000.0f);
             forceSlider.SupportsMultipleBlocks = true;
-            forceSlider.Getter = b => (float)SettingsStore.Get(b, "force_slider", 100000.0f);
+            forceSlider.Getter = b => (float)SettingsStore.Get(b, "force_slider", DefaultForceMWN);
             forceSlider.Setter = (b, v) => SettingsStore.Set(b, "force_slider", (float)LogRound(v));
-            forceSlider.Writer = (b, result) => result.Append(String.Format("{0}N", SIFormat((float)SettingsStore.Get(b, "force_slider", 100000.0f))));
+            forceSlider.Writer = (b, result) => result.Append(String.Format("{0}N", SIFormat((float)SettingsStore.Get(b, "force_slider", DefaultForceMWN))));
             forceSlider.Visible = BlockIsEngine;
             MyAPIGateway.TerminalControls.AddControl<IMyUpgradeModule>(forceSlider);
 
             heightSlider = MyAPIGateway.TerminalControls.CreateControl<IMyTerminalControlSlider, IMyUpgradeModule>("HoverRail_HeightOffset");
             heightSlider.Title = MyStringId.GetOrCompute("Height Offset");
             heightSlider.Tooltip = MyStringId.GetOrCompute("The height we float above the track.");
-            heightSlider.SetLimits(0.3f, 2.5f);
+            heightSlider.SetLimits(0.6f, 1.5f);
             heightSlider.SupportsMultipleBlocks = true;
-            heightSlider.Getter = b => (float)SettingsStore.Get(b, "height_target", 1.25f);
+            heightSlider.Getter = b => (float)SettingsStore.Get(b, "height_target", DefaultHeightM);
             heightSlider.Setter = (b, v) => SettingsStore.Set(b, "height_target", (float)Math.Round(v, 3));
-            heightSlider.Writer = (b, result) => result.Append(String.Format("{0}m", (float)SettingsStore.Get(b, "height_target", 1.25f)));
+            heightSlider.Writer = (b, result) => result.Append(String.Format("{0}m", (float)SettingsStore.Get(b, "height_target", DefaultHeightM)));
             heightSlider.Visible = BlockIsEngine;
             MyAPIGateway.TerminalControls.AddControl<IMyUpgradeModule>(heightSlider);
 
@@ -449,7 +424,7 @@ namespace HoverRail
             damperSlider.SupportsMultipleBlocks = true;
             damperSlider.Getter = b => (float)SettingsStore.Get(b, "dampen_force", 0.5f);
             damperSlider.Setter = (b, v) => SettingsStore.Set(b, "dampen_force", (float)Math.Round(v, 1));
-            damperSlider.Writer = (b, result) => result.Append(String.Format("{0}", (float)SettingsStore.Get(b, "dampen_force", 0.5f)));
+            damperSlider.Writer = (b, result) => result.Append(String.Format("{0}", SIFormat((float)SettingsStore.Get(b, "dampen_force", 0.5f))));
             damperSlider.Visible = BlockIsEngine;
             MyAPIGateway.TerminalControls.AddControl<IMyUpgradeModule>(damperSlider);
 
@@ -459,7 +434,7 @@ namespace HoverRail
             lowerHeightAction.Writer = (b, builder) =>
             {
                 builder.Clear();
-                builder.Append(String.Format("{0} -", (float)SettingsStore.Get(b, "height_offset", 1.25f)));
+                builder.Append(String.Format("{0} -", (float)SettingsStore.Get(b, "height_offset", DefaultHeightM)));
             };
             MyAPIGateway.TerminalControls.AddAction<IMyUpgradeModule>(lowerHeightAction);
 
@@ -469,7 +444,7 @@ namespace HoverRail
             raiseHeightAction.Writer = (b, builder) =>
             {
                 builder.Clear();
-                builder.Append(String.Format("{0} +", (float)SettingsStore.Get(b, "height_offset", 1.25f)));
+                builder.Append(String.Format("{0} +", (float)SettingsStore.Get(b, "height_offset", DefaultHeightM)));
             };
             MyAPIGateway.TerminalControls.AddAction<IMyUpgradeModule>(raiseHeightAction);
 

--- a/Mod/Data/Scripts/HoverRail/HoverRail.cs
+++ b/Mod/Data/Scripts/HoverRail/HoverRail.cs
@@ -1,8 +1,9 @@
 using Sandbox.ModAPI;
-using Sandbox.Common;
+using VRage.Game.Components;
 
-namespace HoverRail {
-	[MySessionComponentDescriptor(MyUpdateOrder.BeforeSimulation)]
+namespace HoverRail
+{
+    [MySessionComponentDescriptor(MyUpdateOrder.BeforeSimulation)]
 	public class HoverRail : MySessionComponentBase {
 		bool inited = false;
 		public void Init() {

--- a/Mod/Data/Scripts/HoverRail/HoverRailEngine.cs
+++ b/Mod/Data/Scripts/HoverRail/HoverRailEngine.cs
@@ -190,6 +190,7 @@ namespace HoverRail
             float height = (float)SettingsStore.Get(Entity, "height_offset", 1.25f);
 
             double forceLimit = (double)(float)SettingsStore.Get(Entity, "force_slider", 100000.0f);
+            bool horizontalForce = (bool)SettingsStore.Get(Entity, "horizontal_force", true);
 
             var hoverCenter = Entity.WorldMatrix.Translation;
             var searchCenter = Entity.WorldMatrix.Translation + Entity.WorldMatrix.Down * 2.499;
@@ -202,7 +203,7 @@ namespace HoverRail
 
             foreach (var guide in activeRailGuides)
             {
-                if (!guide.getGuidance(hoverCenter, ref rail_pos, ref weight_sum, height))
+                if (!guide.getGuidance(hoverCenter, horizontalForce, ref rail_pos, ref weight_sum, height))
                 {
                     // lost rail lock
                     lostGuides.Add(guide);
@@ -230,7 +231,7 @@ namespace HoverRail
 
                     if (guide != null)
                     {
-                        var test = guide.getGuidance(hoverCenter, ref rail_pos, ref weight_sum, height);
+                        var test = guide.getGuidance(hoverCenter, horizontalForce, ref rail_pos, ref weight_sum, height);
 
                         if (test)
                         {
@@ -350,7 +351,7 @@ namespace HoverRail
         public static bool initialized = false;
         public static IMyTerminalControlSlider forceSlider, heightSlider, damperSlider;
         public static IMyTerminalAction lowerHeightAction, raiseHeightAction;
-        public static IMyTerminalControlOnOffSwitch soundOnOffSwitch;
+        public static IMyTerminalControlOnOffSwitch soundOnOffSwitch, horizontalForceSwitch;
 
         public static bool BlockIsEngine(IMyTerminalBlock block)
         {
@@ -419,6 +420,15 @@ namespace HoverRail
             soundOnOffSwitch.Visible = BlockIsEngine;
             MyAPIGateway.TerminalControls.AddControl<IMyUpgradeModule>(soundOnOffSwitch);
 
+            horizontalForceSwitch = MyAPIGateway.TerminalControls.CreateControl<IMyTerminalControlOnOffSwitch, IMyUpgradeModule>("HoverRail_HorizontalForce");
+            horizontalForceSwitch.Title = MyStringId.GetOrCompute("Horizontal Force");
+            horizontalForceSwitch.Tooltip = MyStringId.GetOrCompute("Whether the engine exerts horizontal force.");
+            horizontalForceSwitch.Getter = b => (bool)SettingsStore.Get(b, "horizontal_force", true);
+            horizontalForceSwitch.Setter = (b, v) => SettingsStore.Set(b, "horizontal_force", v);
+            horizontalForceSwitch.OnText = MyStringId.GetOrCompute("On");
+            horizontalForceSwitch.OffText = MyStringId.GetOrCompute("Off");
+            horizontalForceSwitch.Visible = BlockIsEngine;
+            MyAPIGateway.TerminalControls.AddControl<IMyUpgradeModule>(horizontalForceSwitch);
 
             forceSlider = MyAPIGateway.TerminalControls.CreateControl<IMyTerminalControlSlider, IMyUpgradeModule>("HoverRail_ForceLimit");
             forceSlider.Title = MyStringId.GetOrCompute("Force Limit");

--- a/Mod/Data/Scripts/HoverRail/HoverRailJunction.cs
+++ b/Mod/Data/Scripts/HoverRail/HoverRailJunction.cs
@@ -1,17 +1,15 @@
 using System;
 using System.Text;
 using System.Collections.Generic;
-using Sandbox;
 using Sandbox.ModAPI;
 using Sandbox.ModAPI.Interfaces.Terminal;
-using Sandbox.Common;
-using Sandbox.Game.Entities;
-using Sandbox.Game.EntityComponents;
 using Sandbox.Common.ObjectBuilders;
-using Sandbox.Common.Components;
-using VRage.Game;
 using VRage.Utils;
 using VRageMath;
+using VRage.Game.Components;
+using VRage.ObjectBuilders;
+using VRage.ModAPI;
+using VRage.Game.ModAPI;
 
 namespace HoverRail
 {
@@ -21,7 +19,7 @@ namespace HoverRail
         protected MatrixD short_initial, long_initial;
         protected string swivel_short, swivel_long;
 
-        public override void Init(Sandbox.Common.ObjectBuilders.MyObjectBuilder_EntityBase objectBuilder)
+        public override void Init(MyObjectBuilder_EntityBase objectBuilder)
         {
             base.Init(objectBuilder);
             // TODO freeze junctions when they're not moving
@@ -50,7 +48,7 @@ namespace HoverRail
     [MyEntityComponentDescriptor(typeof(MyObjectBuilder_UpgradeModule), false, "HoverRail_Junction_Left_10x-12x_Large")]
     public class HoverRailJunction_12x_Left : HoverRailJunction
     {
-        public override void Init(Sandbox.Common.ObjectBuilders.MyObjectBuilder_EntityBase objectBuilder)
+        public override void Init(MyObjectBuilder_EntityBase objectBuilder)
         {
             base.Init(objectBuilder);
             swivel_short = "jl_swivel_left";
@@ -68,16 +66,25 @@ namespace HoverRail
             var angle = ((bool)SettingsStore.Get(Entity, "junction_turn", false)) ? 8 : 0;
 
             var sw_short = Entity.GetSubpart(swivel_short);
-            sw_short.PositionComp.LocalMatrix = Matrix.CreateRotationY((float)(angle * Math.PI / 180.0)) * short_initial;
+            //var sw_world_ref = sw_short.PositionComp.WorldMatrixRef;
+            //sw_world_ref.SetRotationAndScale(Matrix.CreateRotationY((float)(angle * Math.PI / 180.0)) * short_initial);
+            //sw_short.PositionComp.LocalMatrix = Matrix.CreateRotationY((float)(angle * Math.PI / 180.0)) * short_initial;
+            Matrix short_matrix = Matrix.CreateRotationY((float)(angle * Math.PI / 180.0)) * short_initial;
+            sw_short.PositionComp.SetLocalMatrix(ref short_matrix);
+
             var sw_long = Entity.GetSubpart(swivel_long);
-            sw_long.PositionComp.LocalMatrix = Matrix.CreateRotationY((float)(angle * Math.PI / 180.0)) * long_initial;
+            //var sw_long_ref = sw_long.PositionComp.WorldMatrixRef;
+            //sw_long_ref.SetRotationAndScale(Matrix.CreateRotationY((float)(angle * Math.PI / 180.0)) * long_initial);
+            //sw_long.PositionComp.LocalMatrix = Matrix.CreateRotationY((float)(angle * Math.PI / 180.0)) * long_initial;
+            Matrix long_matrix = Matrix.CreateRotationY((float)(angle * Math.PI / 180.0)) * long_initial;
+            sw_long.PositionComp.SetLocalMatrix(ref long_matrix);
         }
     }
 
     [MyEntityComponentDescriptor(typeof(MyObjectBuilder_UpgradeModule), false, "HoverRail_Junction_Right_10x-12x_Large")]
     public class HoverRailJunction_12x_Right : HoverRailJunction
     {
-        public override void Init(Sandbox.Common.ObjectBuilders.MyObjectBuilder_EntityBase objectBuilder)
+        public override void Init(MyObjectBuilder_EntityBase objectBuilder)
         {
             base.Init(objectBuilder);
             swivel_short = "jr_swivel_right";
@@ -95,9 +102,14 @@ namespace HoverRail
             var angle = ((bool)SettingsStore.Get(Entity, "junction_turn", false)) ? -8 : 0;
 
             var sw_short = Entity.GetSubpart(swivel_short);
-            sw_short.PositionComp.LocalMatrix = Matrix.CreateRotationY((float)(angle * Math.PI / 180.0)) * short_initial;
+            //sw_short.PositionComp.LocalMatrix = Matrix.CreateRotationY((float)(angle * Math.PI / 180.0)) * short_initial;
+            Matrix short_matrix = Matrix.CreateRotationY((float)(angle * Math.PI / 180.0)) * short_initial;
+            sw_short.PositionComp.SetLocalMatrix(ref short_matrix);
+
             var sw_long = Entity.GetSubpart(swivel_long);
-            sw_long.PositionComp.LocalMatrix = Matrix.CreateRotationY((float)(angle * Math.PI / 180.0)) * long_initial;
+            //sw_long.PositionComp.LocalMatrix = Matrix.CreateRotationY((float)(angle * Math.PI / 180.0)) * long_initial;
+            Matrix long_matrix = Matrix.CreateRotationY((float)(angle * Math.PI / 180.0)) * long_initial;
+            sw_long.PositionComp.SetLocalMatrix(ref long_matrix);
         }
     }
 
@@ -235,9 +247,9 @@ namespace HoverRail
                 tracking |= picked_weight > 0;
             }
 
-            // from swivel space into parent local space, recentering the rail piece for straight_guidance
-            var swivel_long_mat = MatrixD.CreateTranslation(1.25 * 4, 0, 0) * this.cubeBlock.GetSubpart(swivel_long).PositionComp.LocalMatrix;
-            var swivel_short_mat = MatrixD.CreateTranslation(1.25 * 3, 0, 0) * this.cubeBlock.GetSubpart(swivel_short).PositionComp.LocalMatrix;
+            // from swivel space into parent local space, recentering the rail piece for straight_guidance - sw_short.PositionComp.WorldMatrixRef
+            var swivel_long_mat = MatrixD.CreateTranslation(1.25 * 4, 0, 0) * this.cubeBlock.GetSubpart(swivel_long).PositionComp.LocalMatrixRef;
+            var swivel_short_mat = MatrixD.CreateTranslation(1.25 * 3, 0, 0) * this.cubeBlock.GetSubpart(swivel_short).PositionComp.LocalMatrixRef;
 
             var sw_long_world_mat = swivel_long_mat * this.cubeBlock.WorldMatrix;
             var sw_short_world_mat = swivel_short_mat * this.cubeBlock.WorldMatrix;

--- a/Mod/Data/Scripts/HoverRail/HoverRailJunction.cs
+++ b/Mod/Data/Scripts/HoverRail/HoverRailJunction.cs
@@ -174,9 +174,9 @@ namespace HoverRail
             weight += mix_weight;
         }
 
-        public override bool getGuidance(Vector3D pos, ref Vector3D guide, ref float weight, float height)
+        public override bool getGuidance(Vector3D pos, bool horizontalForce, ref Vector3D guide, ref float weight, float height)
         {
-            if (!base.getGuidance(pos, ref guide, ref weight, height)) return false;
+            if (!base.getGuidance(pos, horizontalForce, ref guide, ref weight, height)) return false;
 
             var localCoords = Vector3D.Transform(pos, this.cubeBlock.WorldMatrixNormalizedInv);
             // MyLog.Default.WriteLine(String.Format("local coord is {0} [{1}]", localCoords, flip_curve_z));
@@ -210,12 +210,14 @@ namespace HoverRail
                 Vector3D straight_guide = new Vector3D(); float straight_weight = 0.0f;
                 StraightRailGuide.straight_guidance(
                     7 * 1.25f,
+                    horizontalForce,
                     straight_outer_long_to_junction * this.cubeBlock.WorldMatrix,
                     Vector3D.Transform(localCoords, junction_to_straight_outer_long),
                     ref straight_guide, ref straight_weight, height
                 );
                 bool inner_straight_was_picked = StraightRailGuide.straight_guidance(
                     8 * 1.25f,
+                    horizontalForce,
                     straight_inner_long_to_junction * this.cubeBlock.WorldMatrix,
                     Vector3D.Transform(localCoords, junction_to_straight_inner_long),
                     ref straight_guide, ref straight_weight, height
@@ -237,6 +239,7 @@ namespace HoverRail
                 // (but we still have to do the pick process so we don't break the snapping)
                 if (curve_guide_was_picked && outer_curve_was_picked
                 || !curve_guide_was_picked && inner_straight_was_picked
+                || !horizontalForce
                 )
                 {
                     picked_guide = new Vector3D(localCoords.X, height - 1.25, localCoords.Z);
@@ -256,6 +259,7 @@ namespace HoverRail
 
             tracking |= StraightRailGuide.straight_guidance(
                 4 * 1.25f,
+                horizontalForce,
                 sw_long_world_mat,
                 Vector3D.Transform(pos, MatrixD.Invert(sw_long_world_mat)),
                 // subpart rails are at 0, but straight_guidance thinks they are at -1.25
@@ -265,6 +269,7 @@ namespace HoverRail
 
             tracking |= StraightRailGuide.straight_guidance(
                 3 * 1.25f,
+                horizontalForce,
                 sw_short_world_mat,
                 Vector3D.Transform(pos, MatrixD.Invert(sw_short_world_mat)),
                 ref guide, ref weight, height + 1.25f
@@ -272,6 +277,7 @@ namespace HoverRail
 
             tracking |= StraightRailGuide.straight_guidance(
                 1.25f,
+                horizontalForce,
                 straight_outer_short_to_junction * this.cubeBlock.WorldMatrix,
                 Vector3D.Transform(localCoords, junction_to_straight_outer_short),
                 ref guide, ref weight, height,
@@ -279,6 +285,7 @@ namespace HoverRail
             );
             tracking |= StraightRailGuide.straight_guidance(
                 1.25f,
+                horizontalForce,
                 straight_inner_short_to_junction * this.cubeBlock.WorldMatrix,
                 Vector3D.Transform(localCoords, junction_to_straight_inner_short),
                 ref guide, ref weight, height,

--- a/Mod/Data/Scripts/HoverRail/RailGuide.cs
+++ b/Mod/Data/Scripts/HoverRail/RailGuide.cs
@@ -1,10 +1,11 @@
-using System;
-using Sandbox.Game.Entities;
-using VRage.Utils;
+using VRage.Game.Components;
+using VRage.Game.ModAPI;
+using VRage.ModAPI;
 using VRageMath;
 
-namespace HoverRail {
-	abstract class RailGuide {
+namespace HoverRail
+{
+    abstract class RailGuide {
 		public IMyCubeBlock cubeBlock;
 		public string subtypeId;
 		public RailGuide(IMyCubeBlock cubeBlock) {

--- a/Mod/Data/Scripts/HoverRail/RailGuide.cs
+++ b/Mod/Data/Scripts/HoverRail/RailGuide.cs
@@ -42,7 +42,7 @@ namespace HoverRail
 		}
 		// note: new values must be *ADDED* to guide and weight!
 		// height indicates the height that the guide rail should be above the track
-		public virtual bool getGuidance(Vector3D pos, ref Vector3D guide, ref float weight, float height) {
+		public virtual bool getGuidance(Vector3D pos, bool horizontalForce, ref Vector3D guide, ref float weight, float height) {
 			return cubeBlock.IsFunctional;
 		}
 		public static RailGuide fromEntity(IMyEntity ent) {

--- a/Mod/Data/Scripts/HoverRail/SettingsStore.cs
+++ b/Mod/Data/Scripts/HoverRail/SettingsStore.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Collections.Generic;
 using VRage.Serialization;
 using VRage.Utils;
+using VRage.ModAPI;
+using Sandbox.ModAPI;
 
 namespace HoverRail {
 	static class SettingsStore {
@@ -64,7 +66,8 @@ namespace HoverRail {
 			}
 		}
 		public static void SetupNetworkHandlers() {
-			MyAPIGateway.Multiplayer.RegisterMessageHandler(HOVERRAIL_MESSAGE_ID, HandleMessage);
+			//MyAPIGateway.Multiplayer.RegisterMessageHandler(HOVERRAIL_MESSAGE_ID, HandleMessage);
+			MyAPIGateway.Multiplayer.RegisterSecureMessageHandler(HOVERRAIL_MESSAGE_ID, HandleMessage);
 		}
 		public static bool ByteStartsWith(byte[] message, byte[] cmp) {
 			if (message.Length < cmp.Length) return false;
@@ -73,7 +76,7 @@ namespace HoverRail {
 			}
 			return true;
 		}
-		public static void HandleMessage(byte[] data) {
+		public static void HandleMessage(ushort handlerId, byte[] data, ulong steamId, bool isServer) {
 			var b_rebroadcast_marker = Encoding.UTF8.GetBytes(REBROADCAST_MARKER);
 			if (ByteStartsWith(data, b_rebroadcast_marker)) {
 				if (MyAPIGateway.Multiplayer.IsServer) return; // discard

--- a/Mod/Data/Scripts/HoverRail/SlopedRailGuides.cs
+++ b/Mod/Data/Scripts/HoverRail/SlopedRailGuides.cs
@@ -1,9 +1,10 @@
 using System;
 using VRageMath;
-using VRage.Utils;
+using VRage.Game.ModAPI;
 
-namespace HoverRail {
-	static class MinSearch {
+namespace HoverRail
+{
+    static class MinSearch {
 		public static bool find_smallest(ref double where, Func<double, double> fun, double initial_estimate, double from, double to, int iters) {
 			Func<double, double> dfun = f => (fun(f + 0.001) - fun(f - 0.001)) * (1.0 / 0.002);
 			double left = dfun(from), right = dfun(to);

--- a/Mod/Data/Scripts/HoverRail/SlopedRailGuides.cs
+++ b/Mod/Data/Scripts/HoverRail/SlopedRailGuides.cs
@@ -37,8 +37,8 @@ namespace HoverRail
 			this.adjustMatrix = MatrixD.CreateTranslation(0, -1.25, 0) * MatrixD.CreateRotationZ(-angle);
 			this.unadjustMatrix = MatrixD.Invert(this.adjustMatrix);
 		}
-		public override bool getGuidance(Vector3D pos, ref Vector3D guide, ref float weight, float height) {
-			if (!base.getGuidance(pos, ref guide, ref weight, height)) return false;
+		public override bool getGuidance(Vector3D pos, bool horizontalForce, ref Vector3D guide, ref float weight, float height) {
+			if (!base.getGuidance(pos, horizontalForce, ref guide, ref weight, height)) return false;
 			// size: 5x2x1, meaning 12.5 x 5 x 2.5, slope of -1/5
 			// rail begins at x=-6.25 y=1.25 and goes to x=6.25 y=-1.25
 			
@@ -47,7 +47,7 @@ namespace HoverRail
 			// MyLog.Default.WriteLine(String.Format("angle of {0} turns {1} to {2}", Math.Acos(5 / Math.Sqrt(5*5 + 1*1)), localCoords, unrotatedCoords));
 			var length = (float) Math.Sqrt(5*5 + 1*1) * 2.5f;
 			
-			return StraightRailGuide.straight_guidance(length, this.unadjustMatrix * this.cubeBlock.WorldMatrix, unrotatedCoords,
+			return StraightRailGuide.straight_guidance(length, horizontalForce, this.unadjustMatrix * this.cubeBlock.WorldMatrix, unrotatedCoords,
 				ref guide, ref weight, height);
 		}
 	}
@@ -63,8 +63,8 @@ namespace HoverRail
 			double dx = u - x, dy = v - y;
 			return dx * dx + dy * dy;
 		}
-		public override bool getGuidance(Vector3D pos, ref Vector3D guide, ref float weight, float height) {
-			if (!base.getGuidance(pos, ref guide, ref weight, height)) return false;
+		public override bool getGuidance(Vector3D pos, bool horizontalForce, ref Vector3D guide, ref float weight, float height) {
+			if (!base.getGuidance(pos, horizontalForce, ref guide, ref weight, height)) return false;
 			// size: 5x2x1, meaning 12.5 x 5 x 2.5
 			// approximated by y = -(x+6.25)^2*0.008, see http://tinyurl.com/gnm5akr
 			// for X flip, see below
@@ -98,8 +98,8 @@ namespace HoverRail
 			double dx = u - x, dy = v - y;
 			return dx * dx + dy * dy;
 		}
-		public override bool getGuidance(Vector3D pos, ref Vector3D guide, ref float weight, float height) {
-			if (!base.getGuidance(pos, ref guide, ref weight, height)) return false;
+		public override bool getGuidance(Vector3D pos, bool horizontalForce, ref Vector3D guide, ref float weight, float height) {
+			if (!base.getGuidance(pos, horizontalForce, ref guide, ref weight, height)) return false;
 			// size: 5x1x1, meaning 12.5 x 2.5 x 2.5
 			// approximated by y = (x+6.25)^2*0.008-2.5, see http://tinyurl.com/j9q6fc4
 			// except with flipped x because whyy

--- a/Mod/Data/Scripts/HoverRail/StraightRailGuides.cs
+++ b/Mod/Data/Scripts/HoverRail/StraightRailGuides.cs
@@ -1,4 +1,5 @@
 using System;
+using VRage.Game.ModAPI;
 using VRageMath;
 
 static class StraightRailConstants {

--- a/Mod/Data/Scripts/HoverRail/StraightRailGuides.cs
+++ b/Mod/Data/Scripts/HoverRail/StraightRailGuides.cs
@@ -13,7 +13,7 @@ namespace HoverRail {
 		float halfsize;
 		public StraightRailGuide(IMyCubeBlock cubeBlock, float halfsize) : base(cubeBlock) { this.halfsize = halfsize; }
 		// also used in sloped rail
-		public static bool straight_guidance(float halfsize, MatrixD cubeMatrix, Vector3D localCoords,
+		public static bool straight_guidance(float halfsize, bool horizontalForce, MatrixD cubeMatrix, Vector3D localCoords,
 			ref Vector3D guide, ref float weight, float height,
 			bool apply_overhang = true
 		) {
@@ -34,17 +34,17 @@ namespace HoverRail {
 				myWeight = 1.0f;
 			}
 			
-			var localRail = new Vector3D(localCoords.X, height - 1.25, 0);
+			var localRail = new Vector3D(localCoords.X, height - 1.25, horizontalForce ? 0 : localCoords.Z);
 			// DebugDraw.Sphere(Vector3D.Transform(localRail, cubeMatrix), 0.2f, Color.Red);
 			weight += myWeight;
 			guide += Vector3D.Transform(localRail, cubeMatrix) * myWeight;
 			return true;
 		}
-		public override bool getGuidance(Vector3D pos, ref Vector3D guide, ref float weight, float height) {
-			if (!base.getGuidance(pos, ref guide, ref weight, height)) return false;
+		public override bool getGuidance(Vector3D pos, bool horizontalForce, ref Vector3D guide, ref float weight, float height) {
+			if (!base.getGuidance(pos, horizontalForce, ref guide, ref weight, height)) return false;
 			
 			var localCoords = Vector3D.Transform(pos, this.cubeBlock.WorldMatrixNormalizedInv);
-			return straight_guidance(halfsize, this.cubeBlock.WorldMatrix, localCoords, ref guide, ref weight, height);
+			return straight_guidance(halfsize, horizontalForce, this.cubeBlock.WorldMatrix, localCoords, ref guide, ref weight, height);
 		}
 	}
 	class Straight1xRailGuide : StraightRailGuide {


### PR DESCRIPTION
Add engine setting: "Horizontal Force". Defaults to on. If horizontal force is off, the engine only exerts force upwards/downwards.

For instance, when a huge-ass mining drill with eight hover engines wants to take a left turn through a too-small left curve, it's probably a good idea to only turn on horizontal force on the two left center engines. Otherwise, phantom forces arising from misalignment between the engines and the rails would probably cause the mining train to derail dramatically, forcing many many reloads.

You know, in theory.

(I added a commit with your mod changes from Steam too.)

edit: Oh yeah I turned off curve leaning too, it was a stupid idea.